### PR TITLE
config: take maximum_object_size into account

### DIFF
--- a/squid.conf
+++ b/squid.conf
@@ -2826,6 +2826,24 @@ cache_mem {{CACHE_MAX_MEM}} MB
 #Default:
 # cache_replacement_policy lru
 
+#  TAG: maximum_object_size	(bytes)
+#	The default limit on size of objects stored to disk.
+#	This size is used for cache_dir where max-size is not set.
+#	The value is specified in bytes, and the default is 4 MB.
+#
+#	If you wish to get a high BYTES hit ratio, you should probably
+#	increase this (one 32 MB object hit counts for 3200 10KB
+#	hits).
+#
+#	If you wish to increase hit ratio more than you want to
+#	save bandwidth you should leave this low.
+#
+#	NOTE: if using the LFUDA replacement policy you should increase
+#	this value to maximize the byte hit rate improvement of LFUDA!
+#	See replacement_policy below for a discussion of this policy.
+#Default:
+maximum_object_size {{CACHE_MAX_OBJECT_SIZE}} MB
+
 #  TAG: cache_dir
 #	Format:
 #		cache_dir Type Directory-Name Fs-specific-data [options]
@@ -3059,24 +3077,6 @@ cache_dir ufs /var/spool/squid3 {{CACHE_MAX_SIZE}} 16 256
 #	means all responses can be stored.
 #Default:
 # no limit
-
-#  TAG: maximum_object_size	(bytes)
-#	The default limit on size of objects stored to disk.
-#	This size is used for cache_dir where max-size is not set.
-#	The value is specified in bytes, and the default is 4 MB.
-#
-#	If you wish to get a high BYTES hit ratio, you should probably
-#	increase this (one 32 MB object hit counts for 3200 10KB
-#	hits).
-#
-#	If you wish to increase hit ratio more than you want to
-#	save bandwidth you should leave this low.
-#
-#	NOTE: if using the LFUDA replacement policy you should increase
-#	this value to maximize the byte hit rate improvement of LFUDA!
-#	See replacement_policy below for a discussion of this policy.
-#Default:
-maximum_object_size {{CACHE_MAX_OBJECT_SIZE}} MB
 
 #  TAG: cache_swap_low	(percent, 0-100)
 #	The low-water mark for cache object replacement.


### PR DESCRIPTION
According to http://squid-web-proxy-cache.1019090.n4.nabble.com/Problem-with-caching-larger-files-td4666004.html#a4666006, the maximum_object_size must be placed *before* cache_dir to be taken into account