### PR TITLE
firewall blocks access to keyserver.ubuntu.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM sameersbn/ubuntu:14.04.20150604
 MAINTAINER sameer@damagehead.com
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \
  && echo "deb http://ppa.launchpad.net/brightbox/squid-ssl/ubuntu trusty main" >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y squid3-ssl \


### PR DESCRIPTION
some firewalls block the access to the keyserver because of port 11371. With this patch port 80 will be used.