### PR TITLE
Updating to ubuntu:lunar-20221216 (23.04) and squid 5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:bionic-20190612
-LABEL maintainer="sameer@damagehead.com"
+FROM ubuntu:lunar-20221216
+# ubuntu:23.04
+LABEL maintainer="WingsLikeEagles"
 
-ENV SQUID_VERSION=3.5.27 \
+ENV SQUID_VERSION=5.7 \
     SQUID_CACHE_DIR=/var/spool/squid \
     SQUID_LOG_DIR=/var/log/squid \
     SQUID_USER=proxy
@@ -15,3 +16,6 @@ RUN chmod 755 /sbin/entrypoint.sh
 
 EXPOSE 3128/tcp
 ENTRYPOINT ["/sbin/entrypoint.sh"]
+
+# Uncomment below for troubleshooting build
+#CMD /bin/watch ls -l


### PR DESCRIPTION
I put myself as maintainer.  Otherwise, just updating the version numbers.  Works, but Ubuntu image fails on old Docker Engines.